### PR TITLE
Send sleep command on read timeout

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -132,6 +132,8 @@ impl I2cTransport {
         }
         let count = buf[0] as usize;
         if count == 0xff {
+            // Sleep the chip to clear the SRAM when the maximum error read retries have been exhausted
+            self.send_sleep();
             return Err(Error::timeout());
         }
         buf.truncate(count);


### PR DESCRIPTION
The chip will be occasionally stuck in a state where it will not respond. Sending a sleep command when exhausted of read retries will recover on next wake command